### PR TITLE
[Fix] Corrigir criação de tickets em diferentes caixas de entrada

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,36 +13,6 @@ app.use(
   json({ limit: '50mb' }),
 );
 
-
-app.post('/create-provider', async (req: Request, res: Response) => {
-
-  const { account_id, token, url, nameInbox } = req.body;
-
-  if (!account_id || !token || !url) {
-    return res.json({ message: 'error', error: 'Dados inválidos' });
-  }
-
-  try {
-
-    db.exec(`CREATE TABLE IF NOT EXISTS providers (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      account_id INTEGER,
-      token TEXT,
-      url TEXT,
-      nameInbox TEXT
-    )`);
-
-    const stmt = db.prepare(`INSERT INTO providers (account_id, token, url, nameInbox) VALUES (?, ?, ?, ?)`);
-    const info = stmt.run(account_id, token, url, nameInbox);
-
-    res.json({ message: 'ok', info });
-
-
-  } catch (error) {
-    res.json({ message: 'error', error });
-  }
-});
-
 app.post('/webhook/:provider', async (req: Request, res: Response) => {
   try {
     const provider = req.params.provider;

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -48,9 +48,10 @@ export const eventChatWoot = async (body: any): Promise<{ message: string }> => 
           nameInbox TEXT
         )`);
     
-        const stmtExist = db.prepare('SELECT * FROM providers WHERE nameInbox = ?');
-        const instanceDbId = stmtExist.get(accountId);
-        const instanceDbName = stmtExist.get(body.inbox.name);
+        const stmtExistId = db.prepare('SELECT * FROM providers WHERE account_id = ?');
+        const stmtExistName = db.prepare('SELECT * FROM providers WHERE nameInbox = ?');
+        const instanceDbId = stmtExistId.get(accountId);
+        const instanceDbName = stmtExistName.get(body.inbox.name);
         
         if (!instanceDbId || !instanceDbName) {
           const stmt = db.prepare('INSERT INTO providers (account_id, token, url, nameInbox) VALUES (?, ?, ?, ?)');

--- a/src/providers/chatwoot/index.ts
+++ b/src/providers/chatwoot/index.ts
@@ -104,7 +104,7 @@ export const createConversation = async (body: any, accountId: number) => {
     }) as any;
 
     if (contactConversations) {
-      const conversation = contactConversations.payload.find(conversation => conversation.status !== "resolved");
+      const conversation = contactConversations.payload.find(conversation => conversation.status !== "resolved" && conversation.inbox_id == filterInbox.id);
       if (conversation) {
         return conversation.id;
       }


### PR DESCRIPTION
Percebi uma situação em que, ao criar duas caixas de entrada em uma conta, quando uma pessoa envia uma mensagem para uma das caixas de entrada e, em seguida, envia uma mensagem para a segunda caixa de entrada, o ticket não estava sendo criado corretamente. Como resultado, a pessoa estava recebendo uma resposta da primeira caixa de entrada, onde a mensagem original foi enviada.

Isso acontecia devido a uma verificação existente que procurava apenas por tickets não resolvidos, sem levar em consideração a diferença das caixas de entrada (WhatsApp).

Para resolver esse problema, fiz uma alteração na condição do método find(), para que agora ele verifique tanto se o ticket não está resolvido quanto se pertence à caixa de entrada correta. Dessa forma, garantimos que o ticket seja criado corretamente, levando em consideração a caixa de entrada em que a mensagem foi recebida.

Essa alteração garantirá que a pessoa receba uma resposta adequada da caixa de entrada correta, independentemente de qual caixa de entrada ela tenha usado para enviar a mensagem inicialmente.